### PR TITLE
Add public to file path

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ const PORT = 8000
 app.use(express.static('public'))
 
 app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, 'index.html'))
+  res.sendFile(path.join(__dirname, 'public/index.html'))
 })
 
 http.listen(PORT, () => {


### PR DESCRIPTION
As written currently, Express 'magic' is overriding sendFile and serving the index.html file using the static middleware. If you want the sendFile syntax to be accurate (if the name of the file were different, for example) it would need the full correct path, i.e. "public/index.html